### PR TITLE
Implement [FR]#301

### DIFF
--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X0 Y0"), bed_temperature, nozzle_temperature);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X117 Y117"), bed_temperature, nozzle_temperature);
     queue.inject(gcodeBuffer);
     queue.advance();
 


### PR DESCRIPTION

### Description

Starts the Bed Mesh Validation Pattern with one of the Full Circle pads instead of the front left corner.

Achieves this by modifying line#72 in MeshValidationHandler.cpp, to modify the start position parameters of the G26 command.

Since G26 will automatically locate and move to the actual probe position closest to the specified start point to start the pattern, this same change should also work for the CR6-MAX. 

-->

### Requirements

No special requirements.  This change should be fully compatible with all configurations of CR6 printer that is using the CF6 display firmware.

### Benefits

See Issue#301.

### Configurations

Use Release Final 6.1 configs.

### Related Issues

[https://github.com/CR6Community/Marlin/issues/301](url)
